### PR TITLE
Fix Build to use Webdriver Gem over Chromedriver-helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm: 2.5.0
 cache: bundler
 
 before_install:
-  - gem install webdriver -v 3.0.0
+  - gem install webdriver
 
 before_script:
  - chmod +x ./script/cibuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,11 @@ rvm: 2.5.0
 cache: bundler
 
 before_install:
-  - gem install chromedriver-helper -v 1.2.0
+  - gem install webdriver -v 3.0.0
 
 before_script:
  - chmod +x ./script/cibuild
  - export DISPLAY=:99.0 && sh -e /etc/init.d/xvfb start && sleep 3
- - chromedriver-update 73.0.3683.68
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ group :development, :test do
 	gem "rspec"
 	gem "capybara"
 	gem "selenium-webdriver"
-	gem "chromedriver-helper"
+	gem 'webdrivers', '~> 3.0'
 	gem "poltergeist"
 	gem "rack-jekyll"
 	gem "mini_magick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     capybara (2.16.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -19,9 +17,6 @@ GEM
       xpath (~> 2.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     cliver (0.3.2)
     coderay (1.1.2)
     colorator (1.1.0)
@@ -47,7 +42,6 @@ GEM
       yell (~> 2.0)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jekyll (3.6.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -137,6 +131,10 @@ GEM
       ethon (>= 0.8.0)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    webdrivers (3.9.4)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -149,7 +147,6 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  chromedriver-helper
   html-proofer
   jekyll (~> 3.6.0)
   jekyll-feed (~> 0.6)
@@ -165,6 +162,7 @@ DEPENDENCIES
   rspec
   selenium-webdriver
   tzinfo-data
+  webdrivers (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   2.0.2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'pry'
 
 RSpec.configure do |config|
   config.include Capybara::DSL
+  Capybara.server = :webrick
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,13 @@ require 'capybara/rspec'
 require 'rack/jekyll'
 require 'rack/test'
 require 'pry'
+require 'webdrivers'
 
 RSpec.configure do |config|
   config.include Capybara::DSL
   Capybara.server = :webrick
+
+  Webdrivers::Chromedriver.version = '72.0.3626.69'
 
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
# Description
Replaces the chromedriver-helper gem with webdriver. 

Fixes # 
Failures were noted on the CI build. After some investigation it was revealed that capybara was not working. Once that was fixed a version issue was raised in the build. After some research it was noted that chromedriver-helper gem was no longer active and webdriver has replaced it. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update old infomation
- [ ] New blog post or news article
- [ ] New member

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The webmaster as reviewed my code and approved it to be merged
