### PR TITLE
Revert "Matheus - member purge"

### DIFF
--- a/_members/Alan Vilchis.md
+++ b/_members/Alan Vilchis.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Alan Vilchis
+title: App Team Co-Lead
+project: BioT
+img: /assets/images/members/Alan_Vilchis.jpg
+email: alan.vilchis@hotmail.com
+biography: >
+  Alan Vilchis is currently a fourth-year student on a Combined Honors Program in Physics and Astronomy from the University of British Columbia. In his most recent projects he has focused on developing his data analysis skills using Machine Learning and Data Science. Getting involved in projects beyond his area of specialization has really sparked an interest to be involved in multi-disciplinary projects as a way of growing both personally and professionally.
+linkedin: https://www.linkedin.com/in/alan-vilchis-6101b1153/
+---

--- a/_members/Alina Chalanuchpong.md
+++ b/_members/Alina Chalanuchpong.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Alina Chalanuchpong
+title: Green Joule Subteam Lead
+project: Green Joule
+img: /assets/images/members/Alina.jpg
+biography: >
+ Alina is a third-year student specializing in Microbiology and Immunology. She is passionate about the powerful applications of micro-organisms in industries. She is eager to explore the sustainable growth of algae and the generation of biofuel from its biomass. Alina is currently the sub-team lead for the algae growth division and hopes to inspire others and learn more about the algae’s metabolism and its application.
+
+linkedin: https://www.linkedin.com/in/alina-chalanuchpong/
+---

--- a/_members/Azha Aslam.md
+++ b/_members/Azha Aslam.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 5000
+name: Azha Aslam
+project: Green Joule
+title: Green Joule Team Member
+img: /assets/images/members/azha.jpg
+email: azha@alumni.ubc.ca
+biography: >
+  Azha Aslam is a 2nd year Chemical Engineering student. She is part of the Green Joule team and is interested in biological applications of engineering. She is also interested in sustainability and renewable energy sources. 
+linkedin: https://www.linkedin.com/in/azha-aslam-661a1114b/
+---

--- a/_members/Brandon Chen.md
+++ b/_members/Brandon Chen.md
@@ -1,11 +1,11 @@
 ---
 layout: member
-weight: 2
+weight: 50
 name: Brandon Chen
 project: chemecar
-title: VP Internal
+title: Facilities Chair
 img: /assets/images/members/brandon.jpg
 biography: >
-  Brandon is going into his third year of Chemical Engineering, after completing a co-op position and doing a semester abroad. He was involved with the ChemE Car project as a chemical sub-team lead for two years, and as the Facilities Chair for a one year. Brandon is currently serving the Vice President - Internal. Brandon loves all things food, and can usually be found in the kitchen eating and cooking dishes from around the world. 
+  Brandon Chen is a 2nd year student in Chemical Engineering currently on a Co-op term. In his second year on the Chem-E Car team, Brandon is leading the  Senior Laboratory team in designing a new timing mechanism using safer, more economical chemicals. Brandon is also an active member of the Algae team, where he focuses on extraction of chemicals from algae. When he's not working in the lab, Brandon is trying to predict the weather. 
 linkedin: https://www.linkedin.com/in/brandon-chen-23a414129/
 ---

--- a/_members/Caitlin Lee.md
+++ b/_members/Caitlin Lee.md
@@ -1,0 +1,10 @@
+---
+layout: member
+weight: 100000
+name: Caitlin Lee
+title: Advisor
+img: /assets/images/members/caitlin.jpg
+email: caitlin.lee@alumni.ubc.ca
+biography: Caitlin is a 3rd year chemical engineering student. She started off on the Chem-E Car team three years ago and is currently focusing on her 3rd year courses, while giving advice to our Envision family when needed. Not only is she capable of whipping up 3D parts using SolidWorks in 2 seconds or styling a chassis in 3, she can also dance her way into the American Ballet Theatre (her friends swear she can).
+linkedin: https://www.linkedin.com/in/caitlin-lee-82133a141/
+---

--- a/_members/Dina Shehata.md
+++ b/_members/Dina Shehata.md
@@ -1,0 +1,14 @@
+﻿---
+layout: member
+weight: 5000
+name: Dina Shehata
+project: Green Joule
+title: Extraction Sub-team Member
+img: /assets/images/members/Dina.jpg
+email: dina.shehata117@gmail.com
+biography: >
+  Dina Shehata is a first year Engineering student.  She is very interested in making renewable energies more accessible and efficient and as a result is very committed to creating an optimal and cost-effect growth procedure for algae biofuel. Dina hopes to use her past research experience gained from previous biochemical research internships in order to be dedicated and contribute effectively to the project and more specifically Green Joule's extraction sub-team.
+
+linkedin: www.linkedin.com/in/dina-shehata-210392147
+
+---

--- a/_members/Emmanuel Balogun.md
+++ b/_members/Emmanuel Balogun.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Emmanuel Balogun
+project: chemecar
+title: Envision Communication Chair
+img: /assets/images/members/default.png
+email: chemecar@ubcenvision.com
+biography: >
+  Emmanuel Balogun is a third year Materials Engineering student at UBC. He is the Jr. Mechanical Team Lead of Chem-E-Car and has used that as a platform to become Communications Chair for UBC Envision. His enthusiasm in innovation and passion for athletics has motivated him to further explore how materials science can be manipulated with techonology to aid athletic performace, as well as improve overall human interaction with dynamic materials. He aims to use the knowledge and technical experience acquired from his degree and work with Chem-E-Car, to facilitate this investigation.
+linkedin: https://www.linkedin.com/in/emmanuel-balogun-87958013b
+---

--- a/_members/Grania Jain.md
+++ b/_members/Grania Jain.md
@@ -2,8 +2,8 @@
 layout: member
 weight: 50
 name: Grania Jain
-project: agrobot
-title: team member
+project: chemecar
+title: Chem-E-Car Captain
 img: /assets/images/members/Grania.jpg
 email: chemecar@ubcenvision.com
 biography: >

--- a/_members/Jaden King.md
+++ b/_members/Jaden King.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 5000
+name: Jaden King
+project: chemecar
+title: Power Source Team Member
+img: /assets/images/members/Jaden.jpg
+email: kinger3944@gmail.com
+biography: >
+  Jaden King is a third year Chemical & Biological Engineering student at UBC and is a member of the Chem-E-Car Power Source team. He has a deep interest in fuel cell development and a passion for renewable energy. These interests keep him motivated in the team and create a desire to better society through clean energy solutions.
+linkedin: https://www.linkedin.com/in/jaden-king-29b061151/
+---

--- a/_members/Jayg Dimayacyac.md
+++ b/_members/Jayg Dimayacyac.md
@@ -1,11 +1,11 @@
 ---
 layout: member
-weight: 50
+weight: 1
 name: Jayg Dimayacyac
 project: chemecar
-title: Advisor
+title: President
 img: /assets/images/members/jayg.jpg
-email: jayg.dimayacyac@gmail.com
+email: president@ubcenvision.com
 biography: >
   Jayg Dimayacyac is a third year Chemical Engineering student who is working towards a Bachelors' in Applied Science with a minor in Commerce. As president of Envision, he oversees the goals of Envision, as well as its people, hoping to provide them with substantial professional development to launch them into their careers. Jayg has received plenty of achievements through Envision himself, including winning gold with his team at the Regional Chem-E-Car competition, winning silver at the AIChE Regional Paper Competition, and having the opportunity to qualify for the National level in both competitions. Outside of Envision and Chem-E-Car, Jayg has gotten to work under the Co-op program, performing research for the pulp and paper industry. In his spare time, Jayg enjoys singing and writing the a cappella pieces for UBC's competitive a cappella group, which competes annually in the ICCA.
 linkedin: https://www.linkedin.com/in/jose-gabriel-jayg-dimayacyac-17bb0a131

--- a/_members/Jordan Wright.md
+++ b/_members/Jordan Wright.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Jordan Wright
+title: Flow Cell Chem Co-Lead
+project: flowcell
+img: /assets/images/members/jordanw.jpg
+email: jordanwright@alumni.ubc.ca
+biography: >
+ Jordan is a 3rd year Chemical & Biological Engineering student who returned to UBC Envision in 2017 from a year-long co-op term in Alberta. After the successes of the Chem-E-Car team in 2015, Jordan's interest in battery project work grew into a passion for sustainable development and student collaboration. Armed with newfound technical skills and a knack for mentorship, Jordan hopes to foster interest and long-term growth in the Canadian green energy market. Jordan, like Sal Khan, is vocal about his belief that anyone can learn anything and, by extension, make a positive impact on the world. 
+linkedin: https://www.linkedin.com/in/jordan-wright-53a606108
+---

--- a/_members/Josh Agustin.md
+++ b/_members/Josh Agustin.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Josh Agustin
+project: Envision
+title: VP Treasurer
+img: /assets/images/members/JoshAgustin.jpg
+email: jagustin570@alumni.ubc.ca
+biography: >
+  Josh Agustin is currently a third year Chemical Engineering student. He has previously worked on the battery for the junior Chem-E-Car team, and later as a financial officer for Chem-E-Car. He attended the 2018 AIChE Regional Conference in Montana, where junior and senior team won first and second place in the poster competition and the Senior Car qualified for the national conference in Pittsburgh. Now as Treasurer for Envision, he is working to restructure financial operations within Envision and aims to assist each venture in acquiring the funding they require.
+linkedin:
+---

--- a/_members/Josh Donaldson.md
+++ b/_members/Josh Donaldson.md
@@ -1,12 +1,12 @@
 ---
 layout: member
-weight: 5
+weight: 100000
 project: BioT
 name: Josh Donaldson
-title: BIoT Team Lead
+title: Advisor
 img: /assets/images/members/josh.jpg
 email: brewing@ubcenvision.com
 biography: >
-  Joshua Donaldson is going into his 4th year of Engineering at UBC. Last year he was the project lead of the CHBeer project where he is working with his team to design a fully-automated brewing system that can be controlled by your phone. He got involved with the project last January when it was first started. Josh attended the 2017 AiChE conference in Minneapolis last October where he, Shams, Siang and Athanasios presented the CHBeer project to over 100 other students from around the North America. His past co-op experience includes Craft Metrics and Rio Tinto. Favorite breweries include Four Winds, Central City, and Postmark! CHeers! 
+  Joshua Donaldson just finished his 3rd year of Chemical Engineering at UBC. Last year he was the project lead of the CHBeer project where he is working with his team to design a fully-automated brewing system that can be controlled by your phone. He got involved with the project last January when it was first started. Josh attended the 2017 AiChE conference in Minneapolis last October where he, Shams, Siang and Athanasios presented the CHBeer project to over 100 other students from around the North America. He is currently on co-op at Craft Metrics; a Vancouver start-up that specializes in sensors and analytics for the craft beverage industry where he is developing a fermentation analysis library in Python. Josh has been passionate about entrepreneurship since a young age when he started his own freelance media company and is currently an executive at Innovation Onboard where he is acting as the Media Coordinator. Favorite breweries include Four Winds, Central City, and Postmark! CHeers! 
 linkedin: https://www.linkedin.com/in/joshua-donaldson-34289245/
 ---

--- a/_members/Krish Prabhakar.md
+++ b/_members/Krish Prabhakar.md
@@ -1,0 +1,15 @@
+---
+layout: member
+weight: 5000
+name: Krish Prabhakar
+project: chemecar
+title: Fuel Cell Sub Team Member
+img: /assets/images/members/default.png
+email: thekrishp@gmail.com
+biography: >
+  Achyuth (Krish) Prabhakar is a third year chemical engineering student who is currently taking classes until April 2019. As a member of Chem-e-car’s fuel cell sub-team, he has the task of fabricating the battery of the car with four other team members. Being an eager new member of Chem-e-car with previous experience in other UBC design teams, he is excited to learn and bring success to the Chem-e-car teams at the 2018 AIChe Chem-e-car Competition 
+  
+
+linkedin: https://www.linkedin.com/in/achyuth-prabhakar-ab6aa0162/
+---
+

--- a/_members/Landon.md
+++ b/_members/Landon.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 50
+name: Landon Jackson
+project: BioT
+title: Brewing Team Lead
+img: /assets/images/members/Landon.jpg
+biography: >
+  Landon Jackson is a 2nd year student in Chemical Engineering currently on a Co-op position at Ballard. Even though it is his first year as part of Envision, he is already having a profound impact on the automated brewing project, BioT, previously CHBeer. Within a few months of becoming lead, CHBeer has already synthesized an industrial standard product and gained department and international recognition. He is committed to learning more about the unit operations and chemical processes and their applications within the industry. Landon is dedicated to to his team and believes that hard work and perseverance are key to success.
+linkedin: https://www.linkedin.com/in/landon-jackson-62907313b/
+---

--- a/_members/Laurie.md
+++ b/_members/Laurie.md
@@ -1,0 +1,14 @@
+---
+layout: member
+weight: 50
+name: Laurie Jiang
+title: Battery Team Lead
+status: alumni
+img: /assets/images/members/laurie.jpg
+email: lauriejiang@alumni.ubc.ca
+year: 2018
+alumni_position: Consultant, Deloitte
+biography: >
+  Laurie  was a bright and charismatic student in Chemical Engineering. She possesses professional experiences in a wide variety of sectors including environmental integrity and energy megaprojects. As logistics co-lead, Laurie hopes to broaden awareness and understanding about technology and innovation in different aspects of engineering. She is a strong advocate for women in leadership and gender parity within STEM fields both at work and in education. 
+linkedin: https://www.linkedin.com/in/lauriejiang/
+---

--- a/_members/Liam Swiednicki.md
+++ b/_members/Liam Swiednicki.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 5000
+name: Liam Swiednicki
+project: BioT
+title: Brewing Team Member
+img: /assets/images/members/Liam.jpg
+email: liammarkam@gmail.com
+biography: Liam is a third year chemical engineering student and member of the BIoT brewing team. As a member of the team he works on developing and improving automated systems that maintain optimal wort conditions during fermentation. Liam hopes to positively affect the outcome of team projects and to acquire skills that will be used both now and in future opportunities.
+linkedin: https://www.linkedin.com/in/liam-swiednicki-523933160/
+---

--- a/_members/Malavan Subramaniam.md
+++ b/_members/Malavan Subramaniam.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 50
+name: Malavan Subramaniam
+project: Green Joule
+title: Green Joule Administrator
+img: /assets/images/members/malavan.jpg
+biography: >
+  Malavan is a 3rd year Chemistry student and is the administrator for UBC Envision’s Algae team. He has a significant interest in the environment and the many solutions that have been proposed to better manage its health, including alternative energy sources such as biofuels. The opportunity to gain further insight into this fascinating idea by joining this team was overly compelling.  
+linkedin: https://www.linkedin.com/in/malavan-subramaniam-647a66122/
+---

--- a/_members/Mani.md
+++ b/_members/Mani.md
@@ -1,0 +1,13 @@
+---
+layout: member
+weight: 50
+name: Mani Massah
+status: ['alumni']
+title: Battery Team Lead 2017
+img: /assets/images/members/mani.jpg
+year: 2017
+alumni_position: Process Design Engineer, Jacobs
+biography: >
+  Mani is a 4th year chemical engineering student with an interest in electrochemistry. He is working on creating alkaline batteries as an alternative to the zinc air batteries that are currently being used in the car. He has recently become very involved with Chem-E-Car and loves hanging out with the team.
+linkedin: https://ca.linkedin.com/in/mani-massah-172907b0
+---

--- a/_members/Matheus Cassol.md
+++ b/_members/Matheus Cassol.md
@@ -1,13 +1,13 @@
 ---
 layout: member
-weight: 1
+weight: 50
 name: Matheus Cassol
 project: admin
-title: President
+title: VP Internal
 img: /assets/images/members/matheus.jpg
 email: m.cassol@alumni.ubc.ca
 biography: >
-  Matheus is going into his third year of Chemical and Biological Engineering after finishing his co-op terms. Matheus first got involved with Envision as a Chem-E-Car Power Source member and continues to help the team as an advisor. Now as President his goal is to improve upon the projects and events started in previous years, and help projects achieve greatness. As a strong believer of students’ potential in influencing the world, Matheus hopes to foster commitment and responsibility, ultimately creating a community that values curiosity, consistency, and above all, collaboration. Matheus loves nature and has the dream of following a research career to positively impact the environment; in the meantime, he will continue playing soccer and tennis, learning about random topics and appreciating good beer and black coffee.
+  Matheus Cassol is a third year Chemical and Biological Engineering student and is currently on a Co-op work term at STEMCELL Technologies. As VP Internal, his goal is to develop an organized and professional work environment designed for excellence, where all members feel valued and respected. He was previously a member in the Power Source team of Chem-E-Car and now helps the team as a Senior Advisor. Matheus believes in students’ potential in influencing the world and therefore, works on fostering commitment and encouraging all members to become leaders within their projects and communities. Matheus is passionate about research and sustainability, pursuing an engineering degree to follow his dream of having a positive impact in the environment with innovative ideas and further development of clean energy technologies.
   
 linkedin: https://www.linkedin.com/in/m-cassol/
 ---

--- a/_members/MattGin.md
+++ b/_members/MattGin.md
@@ -1,0 +1,13 @@
+---
+layout: member
+weight: 5000
+status: new
+name: Matt Gin
+project: BioT
+title: Member
+img: /assets/images/members/MattGin.jpg
+email: mattgin@alumni.ubc.ca 
+biography: >
+  Matt Gin is a 3rd year CHBe student who is really passionate about developing android apps.  He thought that Envision's BioT, formerly ChBeer, project's Android app that monitors and automates a chemical process is really cool..
+linkedin: https://www.linkedin.com/in/matthew-gin/
+---

--- a/_members/Matthew Schultz.md
+++ b/_members/Matthew Schultz.md
@@ -1,0 +1,13 @@
+---
+layout: member
+weight: 50
+name: Matthew Schultz
+title: BioT Project Lead
+project: BioT
+img: /assets/images/members/Matthew.jpg
+email: matthew.schultz@alumni.ubc.ca	
+biography: > 
+  Matthew Schultz is the current BIoT project lead who has been involved in merging the predominately chemical and biological engineering team with the food nutrition health faculty to better understand the fermentation process.  This merger has created a dedicated space to brew along with many student connections with professors who are interested in the fermentation process.  Matthew is currently in his final year of chemical engineering and can't wait to start working in industry in the spring.
+
+linkedin: https://www.linkedin.com/in/matthew-schultz-89794a151/
+---

--- a/_members/Meghan Cooke.md
+++ b/_members/Meghan Cooke.md
@@ -1,11 +1,12 @@
 ---
 layout: member
-weight: 5
+weight: 5000
 name: Meghan Cooke
 project: chemecar
-title: Chem-E-Car Captain
+title: Lab Member
 img: /assets/images/members/Meghan.jpg
 email: meghanacooke@gmail.com
-biography: Meghan Cooke is a second year student in the chemical and biological engineering program at UBC. She is a captain for the Chem-E-Car project. Meghan is also highly involved in her school community outside of Chem-E-Car. Meghan is also a Residence Advisor, advocates for sports around UBC (and participates), and is a member of the Promotions team for Varsity Games. Now after being on the team for a year, Meghan hopes she can take what she's learned and help the team as we work towards the AIChE Chem-E-Car competition. 
+biography: Meghan Cooke is a first year student in the applied sciences (engineering) program at UBC. She is a part of the lab team for the ChemECar project. Meghan is in charge of helping develop a reaction in order to time the car and the motor as it travels the set distance at the competition. Meghan just recently graduated from high school in Ontario. She graduated with honours and received her IB diploma. While taking IB, she took higher level chemistry and wrote her 4,000 word paper on binary phase diagrams of ethanol and water. Now after adding her to the team, Meghan hopes to contribute to the project with her past knowledge of chemistry and to travel to compete this year.
+
 linkedin: https://www.linkedin.com/in/meghan-cooke-a223b1175/
 ---

--- a/_members/Mitchell Ang.md
+++ b/_members/Mitchell Ang.md
@@ -1,0 +1,13 @@
+---
+layout: member
+weight: 50
+name: Mitchell Ang
+status: alumni
+year: 2018
+alumni_position: A Random Location (Touring the world)
+title: Data Analysis Lead
+img: /assets/images/members/mitchell_ang.jpg
+biography: >
+ Mitchell Ang is currently a fourth-year student in Materials Engineering from the University of British Columbia. Before joining UBC Envision, he had experience working with large datasets, ETL and applications that incorporates machine learning. 
+linkedin: https://www.linkedin.com/in/mitchell-ming-ze-ang-92a442a9/
+---

--- a/_members/Odin Mebesius.md
+++ b/_members/Odin Mebesius.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 5000
+name: Odin Mebesius
+project: chemecar
+title: Junior Lab Team Member
+img: /assets/images/members/odin.jpg
+biography: >
+  Odin Mebesius is a first-year engineering student at UBC. As such, this is his first year in UBC Envision where he is part of the lab sub-team for the Junior Chem-E-Car team.
+linkedin: https://www.linkedin.com/in/odin-mebesius 
+---

--- a/_members/Ophela Zhang.md
+++ b/_members/Ophela Zhang.md
@@ -3,7 +3,7 @@ layout: member
 weight: 50
 name: Ophela Zhang
 project: Green Joule
-title: Advisor
+title: Green Joule Captain
 img: /assets/images/members/ophela.jpg
 email: algae@ubcenvision.com
 biography: >

--- a/_members/Osbert Yu.md
+++ b/_members/Osbert Yu.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 5000
+name: Osbert Yu
+project: chemecar
+title: Junior Lab Team Member
+img: /assets/images/members/osbert.jpg
+biography: >
+  Osbert Yu is a 2nd year chemical and biological engineering student at UBC. He is often found in the supermarket reading nutrition labels to discover the specific chemicals we are ingesting in our daily lives. This interest is what brought him to join the Junior Chem-E-Car Lab Team. He is currently creating a reliable stopping mechanism for the chemical-powered car by exploring various clock reactions with others. 
+linkedin: https://www.linkedin.com/in/osbert-yu
+---

--- a/_members/Pranav Misri.md
+++ b/_members/Pranav Misri.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 50
+name: Pranav Misri
+title: Research-Design-Workshop Co-Lead
+project: chemecar
+img: /assets/images/members/pranav.jpg
+biography: >
+  Pranav Misri is a 2nd year student in Materials Engineering. After working as a junior member of the vessel team in his first year at UBC, Pranav rejoined Chem-E-Car as co-lead of the Research-Design-Workshop Team. He is also currently enrolled in the Research Initiative Program under Professor Edouard Asselin's guidance working in labs assisting upper year Materials Engineering students with various projects. 
+linkedin: https://www.linkedin.com/in/pranav-misri-b45015146/
+---

--- a/_members/Rosalyn Carr.md
+++ b/_members/Rosalyn Carr.md
@@ -1,11 +1,11 @@
 ---
 layout: member
-weight: 5
+weight: 5000
 name: Rosalyn Carr 
 project: Green Joule
-title: Green Joule Co-Lead
+title: Monitoring Team Member 
 img: /assets/images/members/Roz.jpg
 email: rosalyncarr@ieee.org 
-biography: Roz is a third year Biomedical Engineering student under both the faculties of Applied Science and Medicine. She is one of two leads for Green Joule this year. When she isn't busy (rarely), you can often find her writing scripts in MATLAB for cellular image processing.
+biography: Rosalyn (Roz) Carr is a second year Biomedical Engineering student studying under both the Faculty of Medicine and Faculty of Applied Science. Passionate about chemistry, software, and all things data, she is planning on specializing in Bioinformatics in hopes of one day of working in the optimization of pathophysiology or data-mining in disease control. Along with her work in the Green Joule Monitoring team, Roz is also involved the IEEE UBC student chapter as an executive for the upcoming Think Engineering 2019 Conference. 
 linkedin: https://www.linkedin.com/in/rosalyncarr/
 ---

--- a/_members/Said.md
+++ b/_members/Said.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 50
+name: Said Zaid-Alkailani
+status: founder
+title: IOB Marketing Lead
+img: /assets/images/members/said.jpg
+biography: >
+  Said Zaid-Alkailani is currently in his 3rd year of his B.ASc. in Chemical and Biological Engineering (CHBE) in UBC. During Said's undergraduate studies, he has been the vice captain of the junior Chem-E-Car team, the second year representative for CHBE and the third year representative for CHBE.
+linkedin: https://www.linkedin.com/in/said-zaid-alkailani-178686135/
+---

--- a/_members/Sandhya Selvakumar.md
+++ b/_members/Sandhya Selvakumar.md
@@ -1,0 +1,11 @@
+---
+layout: member
+weight: 5000
+name: Sandhya Selvakumar
+title: Algae Biofuel Team Member
+project: BioT
+img: /assets/images/members/sandhya.jpg
+biography: >
+  Sandhya Selvakumar is a first-year engineering student at UBC. She has a strong passion for research and an interest in biofuels and clean energy. This is her first year in UBC Envision as part of the Algae Biofuel Team. 
+linkedin: https://www.linkedin.com/in/sandhya-selvakumar-331693153/
+---

--- a/_members/Shannon.md
+++ b/_members/Shannon.md
@@ -1,0 +1,12 @@
+---
+layout: member
+weight: 50
+name: Shannon McInnes
+project: BioT
+title: Instrumentation Lead
+img: /assets/images/members/shannon.jpg
+email: shannon.mcinnes@alumni.ubc.ca
+biography: > 
+  Shannon McInnes is a graduate student in the Masters of Engineering (M.Eng) Mechatronics Design program at UBC with a background in biomedical and clinical engineering. With a passion for instrumentation and design and a love of beer, it was only natural that she join the CHBeer team and work to help improve the brewing process through the integration of sensor systems. Shannon’s work this term has been focussed on the hardware setup and configuration of the temperature sensors and pH sensor using system on a chip (SoC) technology. Her favourite aspect of the CHBeer team is the opportunity to work collaboratively with the other sub-teams to create something everyone can enjoy, a good beer.
+linkedin: https://www.linkedin.com/in/shannon-mcinnes-66999970/
+---

--- a/_members/Shlok Verma.md
+++ b/_members/Shlok Verma.md
@@ -1,12 +1,12 @@
 ---
 layout: member
-weight: 2
+weight: 5000
 name: Shlok Verma	
 project: chemecar
-title: VP External
+title: Circuitry Sub-Team Member
 img: /assets/images/members/Shlok.jpg
 email: shlok.v123@gmail.com
 biography: >
- Shlok is a third year Chemical and Biological Engineering student at UBC. He is the current VP External of UBC Envision and a Circuitry sub team member in Chem-E-Car. He handles the day to day workings of UBC Envision, Assits projects with preperations for competitions, Works with financial rep on sponsorship opportunities. As the circuitry member, Shlok works on building the circuitry component using Arduino and various sensors. He hopes to gain leadership experience and also experience in the tech field. He has a passion for tech, innovation, soccer, and listening to music.
+ Shlok is a 2nd year Chemical and Biological Engineering Student. He has a passion for nanotechnology, programing and anything related to tech. He is a member of the Circuitry Sub-Team in Chem-E-Car. He would be working with Arduino, circuits and sensors to help build the electrical component of the Chem-E-Car which would compete in the annual AIChE competition.
 linkedin: https://www.linkedin.com/in/shlok-verma-419395154/
 ---

--- a/_members/Tasnia Anika.md
+++ b/_members/Tasnia Anika.md
@@ -1,12 +1,12 @@
 ---
 layout: member
-weight: 5
+weight: 5000
 name: Tasnia Naim Anika
 project: Green Joule
-title: Co-Lead
+title: Member 
 img: /assets/images/members/Anika.jpg
 email: anika8397@yahoo.com.sg
 biography: >
- Anika is a third year student in the Biological stream in the department of Chemical and Biological Engineering. She has been in Envision since 2017 and is currently the co-lead of Green Joule this year. Her role is to oversee the team and provide support to the sub-team leads and other members as well as communicating with the advisors. In addition, she researches the best conditions to grow algae under and working in the lab. She is passionate about sustainability and has special interests in pharmaceuticals, and is looking to cultivate her interest in the improvement of the environment in various ways. She loves Harry Potter and Star Wars, reading, and chicken wings. 
+ Anika is a second year student in the department of Chemical and Biological Engineering. She has been in Envision since 2017 and is currently a member of the Growth subteam. Her role is to research the best conditions to grow algae under and working in the lab. She is passionate about sustainability and has special interests in pharmaceuticals, and is looking to cultivate her interest in the improvement of the environment in various ways.  
 linkedin: https://www.linkedin.com/in/tnanika/
 ---

--- a/_members/Veronika Zenova.md
+++ b/_members/Veronika Zenova.md
@@ -1,13 +1,13 @@
 ---
 layout: member
-weight: 5
+weight: 5000
 name: Veronika Zenova
 project: chemecar
-title: Chem E Car Co-Captain
+title: Junior lab sub-team Member
 img: /assets/images/members/Veronika.jpg
 email: nikazen21@gmail.com
 biography: >
-  Veronika is in her second year of Integrated Engineering at UBC, planning to focus her studies in the chemical and biomedical engineering fields. She began as a Lab Team Member and is currently a Captain of Chem-E-Car.  Her goal is to create a positive work environment where members can learn throughout the design process. She also aims to incorporate sustainable design choices and hopes for team's success at the 2020 AIChE Regional Chem-E-Car Competiton. In her free time, Veronika volunteers at a research lab and the Engineering Undergrad Society, takes care of plants and enjoys eating fruit. 
+  Veronika (Nika) Zenova is a first year Engineering student who is a part of the junior lab sub-team 2 of Chem E Car.  Nika helps develop a reaction in order to time the car and the motor as it travels the set distance at the competition.
 
 linkedin: http://www.linkedin.com/in/veronika-zenova-b1948a175
 ---


### PR DESCRIPTION
Reverts UBCEnvision/UBCEnvision.github.io#351

Do not purge. Inactive members should be moved to the alumni page by including `alumni` to their `status` and adding a new `alumni_position` key. See Thanos's file as an example.

- Alumni profiles are tied to blog articles.
- Prospective sponsors will be interested in alumni outcomes.
- Profiles of formerly active members should be retained but @jd4900 or someone can decide whether to keep or purge profiles of very inactive members (short stint, minimal contributions etc.)

Additional suggestions:
- Move all the 'advisors' to the board (if they are still contributing) or 'alumni' to avoid clogging up the main member page
- Team is getting much bigger, probably want to consider adding some optional filters at the top of the page to filter members by project or some other criteria.
- Tweak mobile views for member page, not very mobile friendly